### PR TITLE
feat(iluminacao): adicionar iluminação simples

### DIFF
--- a/aquario.h
+++ b/aquario.h
@@ -66,4 +66,14 @@ void desenharPeixe(Peixe* peixe);
 void adicionarPeixe();
 void inicializarPeixes(int quantidade);
 
+// ILUMINAÇÃO
+
+void inicializarIluminacao(void);
+void habilitarIluminacao(void);
+void desabilitarIluminacao(void);
+void atualizarPosicaoLuz(float x, float y, float z, float w);
+void configurarIntensidade(float ambient, float diffuse, float specular);
+void configurarBrilhoMaterial(float shininess);
+void usarTexturaModulate(int usar);
+
 #endif

--- a/cena.c
+++ b/cena.c
@@ -2,6 +2,8 @@
 #include "aquario.h"
 
 void desenhaCeu() {
+    desabilitarIluminacao();
+
     float tamanho = 100.0f;
 
     glEnable(GL_TEXTURE_2D);
@@ -20,6 +22,8 @@ void desenhaCeu() {
 
     glEnable(GL_DEPTH_TEST);
     glDisable(GL_TEXTURE_2D);
+
+    habilitarIluminacao();
 }
 
 void desenhaCena() {
@@ -42,31 +46,37 @@ void desenhaCena() {
     glBindTexture(GL_TEXTURE_2D, texturaMesa);
     glColor3f(1.0f, 1.0f, 1.0f);
     glBegin(GL_QUADS);
+        glNormal3f(0.0f, 1.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_mesa/2, topo_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_mesa/2, topo_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_mesa/2, topo_mesa,  profundidade_mesa/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-largura_mesa/2, topo_mesa,  profundidade_mesa/2);
         
+        glNormal3f(0.0f, 0.0f, 1.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_mesa/2, topo_mesa, profundidade_mesa/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_mesa/2, topo_mesa, profundidade_mesa/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_mesa/2, topo_mesa - espessura_mesa, profundidade_mesa/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-largura_mesa/2, topo_mesa - espessura_mesa, profundidade_mesa/2);
         
+        glNormal3f(0.0f, 0.0f, -1.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_mesa/2, topo_mesa, -profundidade_mesa/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-largura_mesa/2, topo_mesa - espessura_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_mesa/2, topo_mesa - espessura_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_mesa/2, topo_mesa, -profundidade_mesa/2);
         
+        glNormal3f(-1.0f, 0.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_mesa/2, topo_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f(-largura_mesa/2, topo_mesa, profundidade_mesa/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f(-largura_mesa/2, topo_mesa - espessura_mesa, profundidade_mesa/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-largura_mesa/2, topo_mesa - espessura_mesa, -profundidade_mesa/2);
         
+        glNormal3f(1.0f, 0.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(largura_mesa/2, topo_mesa, -profundidade_mesa/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(largura_mesa/2, topo_mesa - espessura_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f(largura_mesa/2, topo_mesa - espessura_mesa, profundidade_mesa/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f(largura_mesa/2, topo_mesa, profundidade_mesa/2);
 
+        glNormal3f(0.0f, -1.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_mesa/2, topo_mesa - espessura_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_mesa/2, topo_mesa - espessura_mesa, -profundidade_mesa/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_mesa/2, topo_mesa - espessura_mesa,  profundidade_mesa/2);
@@ -83,31 +93,37 @@ void desenhaCena() {
     glBindTexture(GL_TEXTURE_2D, texturaAreia);
     glColor3f(1.0f, 1.0f, 1.0f);
     glBegin(GL_QUADS);
+        glNormal3f(0.0f, 1.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_areia/2, topo_areia, -profundidade_areia/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_areia/2, topo_areia, -profundidade_areia/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_areia/2, topo_areia,  profundidade_areia/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-largura_areia/2, topo_areia,  profundidade_areia/2);
 
+        glNormal3f(0.0f, 0.0f, 1.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_areia/2, topo_areia,  profundidade_areia/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_areia/2, topo_areia,  profundidade_areia/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_areia/2, fundo_aquario,  profundidade_areia/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-largura_areia/2, fundo_aquario,  profundidade_areia/2);
 
+        glNormal3f(0.0f, 0.0f, -1.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_areia/2, topo_areia, -profundidade_areia/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f(-largura_areia/2, fundo_aquario, -profundidade_areia/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_areia/2, fundo_aquario, -profundidade_areia/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f( largura_areia/2, topo_areia, -profundidade_areia/2);
 
+        glNormal3f(-1.0f, 0.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_areia/2, topo_areia, -profundidade_areia/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f(-largura_areia/2, topo_areia,  profundidade_areia/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f(-largura_areia/2, fundo_aquario,  profundidade_areia/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-largura_areia/2, fundo_aquario, -profundidade_areia/2);
 
+        glNormal3f(1.0f, 0.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f( largura_areia/2, topo_areia, -profundidade_areia/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_areia/2, fundo_aquario, -profundidade_areia/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_areia/2, fundo_aquario,  profundidade_areia/2);
         glTexCoord2f(0.0f, 1.0f); glVertex3f( largura_areia/2, topo_areia,  profundidade_areia/2);
 
+        glNormal3f(0.0f, -1.0f, 0.0f);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-largura_areia/2, fundo_aquario, -profundidade_areia/2);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( largura_areia/2, fundo_aquario, -profundidade_areia/2);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( largura_areia/2, fundo_aquario,  profundidade_areia/2);
@@ -143,16 +159,18 @@ void desenhaCena() {
     int numFolhas = 12;
     for(int i = 0; i < numFolhas; i++) {
         glPushMatrix();
-        // Ajuste de posição Y considerando a rotação
         glTranslatef(x_abacaxi, base_abacaxi + 0.55f, z_abacaxi);
         glRotatef(i * (360.0f/numFolhas), 0.0f, 1.0f, 0.0f);
         glRotatef(-25.0f + (i%3)*8, 1.0f, 0.0f, 0.0f);
-        
-        obj = gluNewQuadric();
-        gluCylinder(obj, 0.08f, 0.001f, 0.5f, 8, 1);
-        gluDeleteQuadric(obj);
+
+        GLUquadric* leaf = gluNewQuadric();
+        gluQuadricTexture(leaf, GL_FALSE);
+        gluQuadricNormals(leaf, GLU_SMOOTH);
+        gluCylinder(leaf, 0.08f, 0.001f, 0.5f, 8, 1);
+        gluDeleteQuadric(leaf);
         glPopMatrix();
     }
+
 
     // PEIXES
     for (int i = 0; i < numPeixes; i++) {
@@ -164,54 +182,63 @@ void desenhaCena() {
     float profundidade_agua = PROFUNDIDADE_AQUARIO - 0.01; 
     glColor4f(0.1f, 0.1f, 0.8f, 0.4f);
     glBegin(GL_QUADS);
+        glNormal3f(0.0f, 1.0f, 0.0f);
         glVertex3f(-largura_agua/2, fundo_aquario + ALTURA_AGUA, -profundidade_agua/2);
         glVertex3f( largura_agua/2, fundo_aquario + ALTURA_AGUA, -profundidade_agua/2);
         glVertex3f( largura_agua/2, fundo_aquario + ALTURA_AGUA,  profundidade_agua/2);
         glVertex3f(-largura_agua/2, fundo_aquario + ALTURA_AGUA,  profundidade_agua/2);
         
+        glNormal3f(0.0f, 0.0f, 1.0f);
         glVertex3f(-largura_agua/2, fundo_aquario, profundidade_agua/2);
         glVertex3f( largura_agua/2, fundo_aquario, profundidade_agua/2);
         glVertex3f( largura_agua/2, fundo_aquario + ALTURA_AGUA, profundidade_agua/2);
         glVertex3f(-largura_agua/2, fundo_aquario + ALTURA_AGUA, profundidade_agua/2);
         
+        glNormal3f(0.0f, 0.0f, -1.0f);
         glVertex3f(-largura_agua/2, fundo_aquario, -profundidade_agua/2);
         glVertex3f(-largura_agua/2, fundo_aquario + ALTURA_AGUA, -profundidade_agua/2);
         glVertex3f( largura_agua/2, fundo_aquario + ALTURA_AGUA, -profundidade_agua/2);
         glVertex3f( largura_agua/2, fundo_aquario, -profundidade_agua/2);
 
+        glNormal3f(-1.0f, 0.0f, 0.0f);
         glVertex3f(-largura_agua/2, fundo_aquario, -profundidade_agua/2);
         glVertex3f(-largura_agua/2, fundo_aquario, profundidade_agua/2);
         glVertex3f(-largura_agua/2, fundo_aquario + ALTURA_AGUA, profundidade_agua/2);
         glVertex3f(-largura_agua/2, fundo_aquario + ALTURA_AGUA, -profundidade_agua/2);
         
+        glNormal3f(1.0f, 0.0f, 0.0f);
         glVertex3f(largura_agua/2, fundo_aquario, -profundidade_agua/2);
         glVertex3f(largura_agua/2, fundo_aquario + ALTURA_AGUA, -profundidade_agua/2);
         glVertex3f(largura_agua/2, fundo_aquario + ALTURA_AGUA, profundidade_agua/2);
         glVertex3f(largura_agua/2, fundo_aquario, profundidade_agua/2);
     glEnd();
     
-    // AQUÁRIO
+    // VIDRO
     glColor4f(0.6f, 0.8f, 1.0f, 0.3f);
     glBegin(GL_QUADS);
         // Frente
+        glNormal3f(0.0f, 0.0f, 1.0f);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario, PROFUNDIDADE_AQUARIO/2);
         glVertex3f( LARGURA_AQUARIO/2, fundo_aquario, PROFUNDIDADE_AQUARIO/2);
         glVertex3f( LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, PROFUNDIDADE_AQUARIO/2);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, PROFUNDIDADE_AQUARIO/2);
 
         // Trás
+        glNormal3f(0.0f, 0.0f, -1.0f);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario, -PROFUNDIDADE_AQUARIO/2);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, -PROFUNDIDADE_AQUARIO/2);
         glVertex3f( LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, -PROFUNDIDADE_AQUARIO/2);
         glVertex3f( LARGURA_AQUARIO/2, fundo_aquario, -PROFUNDIDADE_AQUARIO/2);
 
         // Esquerda
+        glNormal3f(-1.0f, 0.0f, 0.0f);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario, -PROFUNDIDADE_AQUARIO/2);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario, PROFUNDIDADE_AQUARIO/2);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, PROFUNDIDADE_AQUARIO/2);
         glVertex3f(-LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, -PROFUNDIDADE_AQUARIO/2);
 
         // Direita
+        glNormal3f(1.0f, 0.0f, 0.0f);
         glVertex3f(LARGURA_AQUARIO/2, fundo_aquario, -PROFUNDIDADE_AQUARIO/2);
         glVertex3f(LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, -PROFUNDIDADE_AQUARIO/2);
         glVertex3f(LARGURA_AQUARIO/2, fundo_aquario + ALTURA_AQUARIO, PROFUNDIDADE_AQUARIO/2);

--- a/iluminacao.c
+++ b/iluminacao.c
@@ -1,0 +1,66 @@
+#include <GL/gl.h>
+#include <GL/glu.h>
+#include "aquario.h"
+
+static GLfloat luzAmbiente[4]  = { 0.20f, 0.20f, 0.20f, 1.0f };
+static GLfloat luzDifusa[4]    = { 0.80f, 0.80f, 0.80f, 1.0f };
+static GLfloat luzEspecular[4] = { 1.00f, 1.00f, 1.00f, 1.0f };
+static GLfloat posicaoLuz[4]   = { 5.0f, 6.0f, 5.0f, 1.0f };
+
+void inicializarIluminacao(void) {
+    glEnable(GL_LIGHTING);
+    glEnable(GL_LIGHT0);
+
+    glEnable(GL_NORMALIZE);
+    glEnable(GL_COLOR_MATERIAL);
+    glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
+    glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, 32.0f);
+
+    glLightfv(GL_LIGHT0, GL_AMBIENT,  luzAmbiente);
+    glLightfv(GL_LIGHT0, GL_DIFFUSE,  luzDifusa);
+    glLightfv(GL_LIGHT0, GL_SPECULAR, luzEspecular);
+    glLightfv(GL_LIGHT0, GL_POSITION, posicaoLuz);
+
+    GLfloat ambienteGlobal[4] = { 0.05f, 0.05f, 0.05f, 1.0f };
+    glLightModelfv(GL_LIGHT_MODEL_AMBIENT, ambienteGlobal);
+
+    glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+}
+
+void habilitarIluminacao(void) {
+    glEnable(GL_LIGHTING);
+    glEnable(GL_LIGHT0);
+}
+
+void desabilitarIluminacao(void) {
+    glDisable(GL_LIGHT0);
+    glDisable(GL_LIGHTING);
+}
+
+void atualizarPosicaoLuz(float x, float y, float z, float w) {
+    posicaoLuz[0] = x;
+    posicaoLuz[1] = y;
+    posicaoLuz[2] = z;
+    posicaoLuz[3] = w;
+    glLightfv(GL_LIGHT0, GL_POSITION, posicaoLuz);
+}
+
+void configurarIntensidade(float ambient, float diffuse, float specular) {
+    for (int i = 0; i < 3; ++i) {
+        luzAmbiente[i]  = ambient * 0.25f;
+        luzDifusa[i]    = diffuse;
+        luzEspecular[i] = specular;
+    }
+    glLightfv(GL_LIGHT0, GL_AMBIENT,  luzAmbiente);
+    glLightfv(GL_LIGHT0, GL_DIFFUSE,  luzDifusa);
+    glLightfv(GL_LIGHT0, GL_SPECULAR, luzEspecular);
+}
+
+void configurarBrilhoMaterial(float shininess) {
+    glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, shininess);
+}
+
+void usarTexturaModulate(int usar) {
+    if (usar) glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+    else     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+}

--- a/peixe.c
+++ b/peixe.c
@@ -31,11 +31,13 @@ void desenharPeixe(Peixe* peixe) {
 
     glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
     glBegin(GL_QUADS);
+        glNormal3f(0.0f, 0.0f, 1.0f);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-hx, -hy,  hz);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( hx, -hy,  hz);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( hx,  hy,  hz);
         glTexCoord2f(0.0f, 0.0f); glVertex3f(-hx,  hy,  hz);
 
+        glNormal3f(0.0f, 0.0f, -1.0f);
         glTexCoord2f(0.0f, 1.0f); glVertex3f(-hx, -hy, -hz);
         glTexCoord2f(1.0f, 1.0f); glVertex3f( hx, -hy, -hz);
         glTexCoord2f(1.0f, 0.0f); glVertex3f( hx,  hy, -hz);
@@ -49,21 +51,25 @@ void desenharPeixe(Peixe* peixe) {
 
     // Lateral esquerda
     glBegin(GL_QUADS);
+        glNormal3f(-1.0f, 0.0f, 0.0f);
         glVertex3f(-hx, -hy, -hz);
         glVertex3f(-hx, -hy,  hz);
         glVertex3f(-hx,  hy,  hz);
         glVertex3f(-hx,  hy, -hz);
     // Lateral direita
+        glNormal3f(1.0f, 0.0f, 0.0f);
         glVertex3f( hx, -hy,  hz);
         glVertex3f( hx, -hy, -hz);
         glVertex3f( hx,  hy, -hz);
         glVertex3f( hx,  hy,  hz);
     // Topo
+        glNormal3f(0.0f, 1.0f, 0.0f);
         glVertex3f(-hx,  hy,  hz);
         glVertex3f( hx,  hy,  hz);
         glVertex3f( hx,  hy, -hz);
         glVertex3f(-hx,  hy, -hz);
     // Fundo
+        glNormal3f(0.0f, -1.0f, 0.0f);
         glVertex3f(-hx, -hy, -hz);
         glVertex3f( hx, -hy, -hz);
         glVertex3f( hx, -hy,  hz);

--- a/recursos.c
+++ b/recursos.c
@@ -75,6 +75,8 @@ void inicializar() {
     texturaPeixe4 = carregaTextura("texturas/peixe4.png");
     texturaPeixe5 = carregaTextura("texturas/peixe5.png");
 
+    inicializarIluminacao();
+
     srand(time(NULL));
     inicializarPeixes(3);
 }


### PR DESCRIPTION
- Novo módulo `iluminacao.c`
- Configuração padrão da GL_LIGHT0, GL_NORMALIZE e GL_COLOR_MATERIAL.
- Adicionado normais nas faces dos objetos para que a iluminação produza resultado correto.